### PR TITLE
All futures

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 
 import PackageDescription
 

--- a/Sources/NIOKit/Extensions/EventLoop/EventLoop+WhenAll.swift
+++ b/Sources/NIOKit/Extensions/EventLoop/EventLoop+WhenAll.swift
@@ -1,0 +1,65 @@
+import NIO
+
+extension EventLoop {
+    /// Returns a new `EventLoopFuture` that succeeds when all of the provided `EventLoopFutures` complete.
+    /// The new `EventLoopFuture` will contain an array of results, maintaining ordering
+    /// for each of the completed `EventLoopFutures`.
+    ///
+    /// The returned `EventLoopFuture` always succeeds, regardless of any failures from the provided futures.
+    ///
+    /// If it is desired to flatten them into a single `EventLoopFuture` that fails on any `EventLoopFuture` failure,
+    /// use `EventLoop.flatten(_:)` or other methods.
+    /// - Parameter futures: An array of futures to gather results from.
+    /// - Returns: A new `EventLoopFuture` with all the results of the provided futures.
+    public func whenAllComplete<T>(_ futures: [EventLoopFuture<T>]) -> EventLoopFuture<[Result<T, Error>]> {
+        let promise: EventLoopPromise<[Result<T, Error>]> = self.newPromise()
+
+        var results = [(Int, Result<T, Error>)]()
+        var remaining = futures.count
+
+        // add callback to each future that stores the error or value result in the same ordering as the futures
+        for (index, future) in futures.enumerated() {
+            future.addAwaitier { result in
+                remaining -= 1
+
+                results.append((index, result))
+
+                if remaining == 0 {
+                    let orderedResults = results
+                        .sorted(by: { return $0.0 < $1.0 })
+                        .map { $0.1 }
+                    promise.succeed(result: orderedResults)
+                }
+            }
+        }
+
+        return promise.futureResult
+    }
+
+    /// Returns a new `EventLoopFuture` that succeeds when all of the provided `EventLoopFutures` complete.
+    ///
+    /// The returned `EventLoopFuture` always succeeds, regardless of any failures from the provided futures.
+    ///
+    /// If it is desired to flatten them into a single `EventLoopFuture` that fails on any `EventLoopFuture` failure,
+    /// use `EventLoop.flatten(_:)` or other methods.
+    /// - Parameter futures: An array of futures to gather results from.
+    /// - Returns: A new `EventLoopFuture` that succeeds after the providied futures complete.
+    public func whenAllComplete<T>(_ futures: [EventLoopFuture<T>]) -> EventLoopFuture<Void> {
+        let promise: EventLoopPromise<Void> = newPromise()
+
+        var remaining = futures.count
+
+        // attach a callback that checks to see if it was the last future to complete to succeed the top-level future
+        futures.forEach {
+            $0.whenComplete {
+                remaining -= 1
+
+                guard remaining == 0 else { return }
+
+                promise.succeed(result: ())
+            }
+        }
+
+        return promise.futureResult
+    }
+}

--- a/Sources/NIOKit/Utils/EventLoopFuture.swift
+++ b/Sources/NIOKit/Utils/EventLoopFuture.swift
@@ -1,0 +1,8 @@
+import NIO
+
+extension EventLoopFuture {
+    func addAwaitier(callback: @escaping (Result<T, Error>) -> ()) {
+        self.whenSuccess { callback(.success($0)) }
+        self.whenFailure { callback(.failure($0)) }
+    }
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -4,6 +4,8 @@ import XCTest
 
 var tests = [
     testCase(NIOKitTests.allTests),
-    testCase(FutureOperatorTests.allTests)
+    testCase(FutureOperatorTests.allTests),
+    testCase(EventLoopWhenAllTests.allTests),
 ]
 XCTMain(tests)
+

--- a/Tests/NIOKitTests/Extensions/EventLoop/EventLoop+WhenAllTests.swift
+++ b/Tests/NIOKitTests/Extensions/EventLoop/EventLoop+WhenAllTests.swift
@@ -1,0 +1,85 @@
+import NIO
+@testable import NIOKit
+import XCTest
+
+final class EventLoopWhenAllTests: XCTestCase {
+    private var group: EventLoopGroup!
+    private var eventLoop: EventLoop {
+        return group.next()
+    }
+
+    override func setUp() {
+        self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    }
+
+    override func tearDown() {
+        XCTAssertNoThrow(try self.group.syncShutdownGracefully())
+        self.group = nil
+    }
+
+    func testFailuresStillSucceed() {
+        let future: EventLoopFuture<[Result<Bool, Error>]> = eventLoop.whenAllComplete([
+            eventLoop.newSucceededFuture(result: true),
+            eventLoop.newFailedFuture(error: NSError(domain: "NIOKit", code: 1, userInfo: nil))
+        ])
+        XCTAssertNoThrow(try future.wait())
+    }
+
+    func testSuccessProvidesResults() throws {
+        let results: [Result<Int, Error>] = try eventLoop.whenAllComplete([
+            eventLoop.newSucceededFuture(result: 3),
+            eventLoop.newFailedFuture(error: NSError(domain: "NIOKit", code: 1, userInfo: nil)),
+            eventLoop.newSucceededFuture(result: 10),
+            eventLoop.newFailedFuture(error: NSError(domain: "NIOKit", code: 3, userInfo: nil)),
+            eventLoop.newSucceededFuture(result: 5)
+        ]).wait()
+
+        for i in [0, 2, 4] {
+            XCTAssertNoThrow(try results[i].get())
+        }
+
+        for i in [1, 3] {
+            XCTAssertThrowsError(try results[i].get())
+        }
+    }
+
+    func testSuccessMaintainsOrder() throws {
+        func createExpensiveFuture(id: Int, result: Int) -> EventLoopFuture<Int> {
+            let promise: EventLoopPromise<Int> = eventLoop.newPromise()
+
+            DispatchQueue(label: "background_thread_\(id)").async {
+                usleep(UInt32(id * 5 * 50_000))
+                promise.succeed(result: result)
+            }
+
+            return promise.futureResult
+        }
+
+        let results: [Result<Int, Error>] = try eventLoop.whenAllComplete([
+            createExpensiveFuture(id: 3, result: 3),
+            createExpensiveFuture(id: 2, result: 10),
+            eventLoop.newFailedFuture(error: NSError(domain: "NIOKit", code: 1, userInfo: nil)),
+            createExpensiveFuture(id: 1, result: 15)
+        ]).wait()
+
+        XCTAssertEqual(try results[0].get(), 3)
+        XCTAssertEqual(try results[1].get(), 10)
+        XCTAssertEqual(try results[3].get(), 15)
+    }
+
+    func testNotifyFailuresStillSucceed() {
+        XCTAssertNoThrow(try eventLoop.whenAllComplete([
+            eventLoop.newSucceededFuture(result: true),
+            eventLoop.newFailedFuture(error: NSError(domain: "NIOKit", code: 1, userInfo: nil))
+        ]).thenThrowing { }.wait())
+    }
+}
+
+extension EventLoopWhenAllTests {
+    static var allTests = [
+        ("test_failures_stillSucceed", testFailuresStillSucceed),
+        ("test_success_providesResults", testSuccessProvidesResults),
+        ("test_success_maintainsOrder", testSuccessMaintainsOrder),
+        ("test_notify_failures_stillSucceed", testNotifyFailuresStillSucceed),
+    ]
+}

--- a/circle.yml
+++ b/circle.yml
@@ -1,23 +1,15 @@
 version: 2
 
 jobs:
-  macos:
-    macos:
-      xcode: "10.1.0"
-    steps:
-      - checkout
-      - run: swift build
-      - run: swift test
+#  macos:
+#    macos:
+#      xcode: "10.1.0"
+#    steps:
+#      - checkout
+#      - run: swift build
+#      - run: swift test
 
   linux:
-    docker:
-      - image: swift:4.2
-    steps:
-      - checkout
-      - run: swift build
-      - run: swift test
-
-  linux-50:
     docker:
       - image: codevapor/swift:5.0
     steps:
@@ -27,7 +19,7 @@ jobs:
 
   linux-release:
     docker:
-      - image: swift:4.2
+      - image: codevapor/swift:5.0
     steps:
       - checkout
       - run: swift build -c release
@@ -38,6 +30,5 @@ workflows:
   tests:
     jobs:
       - linux
-      - linux-50
       - linux-release
       - macos


### PR DESCRIPTION
Implementation of #12 

Example usage:

```swift
let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
let results = try elg.next().whenAllComplete(
    someFunctionThatReturnsIntFuture(),
    someFunctionThatReturnsIntFuture()
).wait()

// results = [Result<Int, Error>]
// results.count == 2
```